### PR TITLE
DEPL-11980 Investigate "OSError: [Errno 9] Bad file descriptor" when …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM openjdk:jre-slim
+FROM openjdk:jre-alpine
 MAINTAINER XebiaLabs "info@xebialabs.com"
-RUN apt-get update && apt-get install -y supervisor wget
+RUN apk update && apk add supervisor wget
 RUN wget -O /tmp/xl-deploy-trial-server.zip https://dist.xebialabs.com/xl-deploy-trial-server.zip && \
     mkdir -p /opt/xld && unzip /tmp/xl-deploy-trial-server.zip -d /opt/xld && \
     mv /opt/xld/xl-deploy-*-server /opt/xld/server && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM openjdk:jre-alpine
+FROM openjdk:jre-slim
 MAINTAINER XebiaLabs "info@xebialabs.com"
-RUN apk update && apk add supervisor wget
+RUN apt-get update && apt-get install -y supervisor wget
 RUN wget -O /tmp/xl-deploy-trial-server.zip https://dist.xebialabs.com/xl-deploy-trial-server.zip && \
     mkdir -p /opt/xld && unzip /tmp/xl-deploy-trial-server.zip -d /opt/xld && \
     mv /opt/xld/xl-deploy-*-server /opt/xld/server && \

--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -1,0 +1,18 @@
+FROM openjdk:jre-slim
+MAINTAINER XebiaLabs "info@xebialabs.com"
+RUN apt-get update && apt-get install -y supervisor wget
+RUN wget -O /tmp/xl-deploy-trial-server.zip https://dist.xebialabs.com/xl-deploy-trial-server.zip && \
+    mkdir -p /opt/xld && unzip /tmp/xl-deploy-trial-server.zip -d /opt/xld && \
+    mv /opt/xld/xl-deploy-*-server /opt/xld/server && \
+    rm -rf /tmp/xl-deploy-trial-server.zip
+RUN wget -O /tmp/xl-deploy-trial-cli.zip https://dist.xebialabs.com/xl-deploy-trial-cli.zip && \
+    mkdir -p /opt/xld && \
+    unzip /tmp/xl-deploy-trial-cli.zip -d /opt/xld && \
+    mv /opt/xld/xl-deploy-*-cli /opt/xld/cli && \
+    rm -rf /tmp/xl-deploy-trial-cli.zip
+ADD resources/deployit.conf /opt/xld/server/conf/deployit.conf
+ADD resources/supervisord.conf /etc/supervisord.conf
+RUN /opt/xld/server/bin/run.sh -setup -reinitialize -force \
+    && ln -fs /license/deployit-license.lic /opt/xld/server/conf/deployit-license.lic
+CMD ["/usr/bin/supervisord"]
+EXPOSE 4516

--- a/README.md
+++ b/README.md
@@ -17,17 +17,20 @@ Docker image that has XLD installed.
 
 ## Supported tags
 
-* `latest`, `v7.2.0.2`, `latest-slim`
-* `v7.2.0.1`
-* `v7.1.0.1`
-* `v7.0.0.1`
-* `v7.0.0.0-alpha2`
-* `v7.0.0.0-alpha1`
-* `v6.2.0.1`
-* `v6.1.0.1`
-* `v6.0.1.2`
-* `v6.0.1.1`
-* `v5.5.5.1`
++ `latest` [Dockerfile](https://github.com/xebialabs-community/xl-docker-demo-xld/blob/master/Dockerfile)
++ `latest-slim` [Dockerfile](https://github.com/xebialabs-community/xl-docker-demo-xld/blob/master/Dockerfile-slim)
++ `v7.2.0.3`, `v7.2.0.3-alpine` [Dockerfile](https://github.com/xebialabs-community/xl-docker-demo-xld/blob/v7.2.0.3/Dockerfile)
++ `v7.2.0.3-slim` [Dockerfile](https://github.com/xebialabs-community/xl-docker-demo-xld/blob/v7.2.0.3/Dockerfile-slim)
++ `v7.2.0.2`
++ `v7.2.0.1`
++ `v7.1.0.1`
++ `v7.0.0.1`
++ `v7.0.0.0-alpha2`
++ `v7.0.0.0-alpha1`
++ `v6.2.0.1`
++ `v6.1.0.1`
++ `v6.0.1.2`
++ `v6.0.1.1`
 
 ## Dockerfile
 ### `Dockerfile` builds the container with base image `jre-alpine`

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Docker image that has XLD installed.
 
 ## Supported tags
 
-* `latest`, `v7.2.0.2`
+* `latest`, `v7.2.0.2`, `v7.2.0.2-slim`
 * `v7.2.0.1`
 * `v7.1.0.1`
 * `v7.0.0.1`

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Docker image that has XLD installed.
 
 ## Supported tags
 
-* `latest`, `v7.2.0.2`, `v7.2.0.2-slim`
+* `latest`, `v7.2.0.2`, `latest-slim`
 * `v7.2.0.1`
 * `v7.1.0.1`
 * `v7.0.0.1`
@@ -28,6 +28,10 @@ Docker image that has XLD installed.
 * `v6.0.1.2`
 * `v6.0.1.1`
 * `v5.5.5.1`
+
+## Dockerfile
+### `Dockerfile` builds the container with base image `jre-alpine`
+### `Dockerfile-slim` builds the container with base image `jre-slim`
 
 ## Starting
 


### PR DESCRIPTION
…running XL Deploy in Docker

Jython is having issue while uploading file with the alpine linux base image. The fix is to use other distribution as base image. We tested it with jre-slim, it uses Debian as base image. The caveat is, it increases the size of the image by 100 MB and as the base image of this docker image is changed the impact will also be on the xl-se-docker-demo repository as it uses this image as base image. We need to fix those as well.